### PR TITLE
Fixes CMake Dep error: Could NOT find XCB (missing: XFIXES)

### DIFF
--- a/CI/install-dependencies-linux.sh
+++ b/CI/install-dependencies-linux.sh
@@ -45,7 +45,9 @@ sudo apt-get install -y \
         qtbase5-dev \
         qtbase5-private-dev \
         libqt5svg5-dev \
-        swig
+        swig \
+        libxcb-shape0-dev \
+        libxcb-xfixes0-dev
 
 # build cef
 wget --quiet --retry-connrefused --waitretry=1 https://cdn-fastly.obsproject.com/downloads/cef_binary_${LINUX_CEF_BUILD_VERSION}_linux64.tar.bz2


### PR DESCRIPTION
Issue when running CI Build Bot install dependencies:

```
CMake Error at /usr/share/cmake-3.18/Modules/FindPackageHandleStandardArgs.cmake:165 (message):
  Could NOT find XCB (missing: XFIXES)
Call Stack (most recent call first):
  /usr/share/cmake-3.18/Modules/FindPackageHandleStandardArgs.cmake:458 (_FPHSA_FAILURE_MESSAGE)
  cmake/Modules/FindXCB.cmake:236 (find_package_handle_standard_args)
  plugins/linux-capture/CMakeLists.txt:9 (find_package)
```

Installing the packages newly listed in the deps file fixes this issue